### PR TITLE
Safer regex code

### DIFF
--- a/code/R/do_analysis.R
+++ b/code/R/do_analysis.R
@@ -100,6 +100,6 @@ var_names <- tibble(
 )
 
 save(
-  list = c("smp_da", "var_names", ls(pattern = "fig_*"), ls(pattern = "tab_*")),
+  list = c("smp_da", "var_names", ls(pattern = "^fig_*"), ls(pattern = "^tab_*")),
   file = "output/results.rda"
 )


### PR DESCRIPTION
Only looks for object names that _start_ with "fig" or "tab".